### PR TITLE
enable build on mac

### DIFF
--- a/conn.cpp
+++ b/conn.cpp
@@ -28,8 +28,21 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/time.h>
+#include <signal.h>
 #include "conn.h"
 #include "drvfr.h"
+
+#ifdef __APPLE__
+#ifndef TEMP_FAILURE_RETRY
+# define TEMP_FAILURE_RETRY(expression) \
+  (__extension__                                                              \
+    ({ long int __result;                                                     \
+       do __result = (long int) (expression);                                 \
+       while (__result == -1L && errno == EINTR);                             \
+       __result; }))
+#endif
+#endif
+
 
 /**********************************************************
  * Local functions & procedures                           *


### PR DESCRIPTION
почему-то в маковом unistd.h нет TEMP_FAILURE_RETRY
